### PR TITLE
Checkout files with Git LFS when deploying

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -22,6 +22,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
 
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v2


### PR DESCRIPTION
# 概要
現状、Git LFS のメタデータがそのまま配信されてしまっており、画像が見えなくなっています。
そこで、デプロイ時に Git LFS で管理された画像ファイルを扱えるようにします。
